### PR TITLE
fix: use GitHub App for release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,7 +12,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: googleapis/release-please-action@v4.2.0
+      - uses: "actions/create-github-app-token@v2.1.1"
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: "actions/checkout@v5.0.0"
+      - uses: "googleapis/release-please-action@v4.3.0"
         with:
           release-type: go
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This should resolve a defect resulting from the default `GITHUB_TOKEN` not triggering subsequent Actions workflows.