### PR TITLE
feat: gracefully exit if fzf cancelled

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	goversion "github.com/caarlos0/go-version"
 	"github.com/hugginsio/talosctx/internal"
+	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +31,11 @@ var rootCmd = &cobra.Command{
 		var chosenContext string
 		if len(args) == 0 {
 			chosenContext, err = internal.Select(talosconfig.Contexts, previousContext)
+			if errors.Is(err, fuzzyfinder.ErrAbort) {
+				fmt.Println("Cancelled, context unchanged.")
+				os.Exit(0)
+			}
+
 			if err != nil {
 				fmt.Println("Failure while selecting context:", err)
 				os.Exit(5)


### PR DESCRIPTION
Instead of exiting with an error code, print `Cancelled, context unchanged.` and exit gracefully.